### PR TITLE
Add Dockerfile for server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN python -m spacy download en
 FROM node:6
 COPY --from=spacy /usr/local /usr/local/
 RUN ldconfig
-WORKDIR /app
+WORKDIR /usr/src/app
 COPY package*.json ./
 RUN npm install && npm cache clean --force
 COPY . ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY --from=spacy /usr/local /usr/local/
 RUN ldconfig
 WORKDIR /app
 COPY package*.json ./
-RUN npm install
+RUN npm install && npm cache clean --force
 COPY . ./
 CMD ["npm", "start"]
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3 as spacy
+RUN pip install wheel socketIO-client spacy
+RUN python -m spacy download en
+
+FROM node:6
+COPY --from=spacy /usr/local /usr/local/
+RUN ldconfig
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . ./
+CMD ["npm", "start"]
+EXPOSE 3000

--- a/server-config.js
+++ b/server-config.js
@@ -1,5 +1,7 @@
+const fs = require('fs');
+
 module.exports = {
     port: 3000,
     internalClientPort: 3001,
-    authKey: 'ASDASD'
+    authKey: process.env.AUTH_KEY || fs.readFileSync('/run/secrets/authkey', { encoding: 'utf-8' }).trim()
 };


### PR DESCRIPTION
This Dockerfile builds an image for running the server. A multi-stage build is used where the first stage installs the Python bits, and the second stage grabs all of /usr/local and dumps that on top of the stock official node image. After a dynamic linker cache rebuild, everything seems to work just fine.